### PR TITLE
Add Multiple checkout module support

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/Block/Adminhtml/Order/Charge/Grid.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Block/Adminhtml/Order/Charge/Grid.php
@@ -73,21 +73,21 @@ class Mundipagg_Paymentmodule_Block_Adminhtml_Order_Charge_Grid extends Mage_Adm
             'type'   => 'currency',
             'currency_code' => $currency,
             'filter' => false,
-            'sortable'  => false,
+            'sortable'  => false
         ]);
  
         $this->addColumn('status', [
             'header' => $helper->__('Status'),
             'index'  => 'status',
             'filter' => false,
-            'sortable'  => false,
-        ));
+            'sortable'  => false
+        ]);
  
         $this->addColumn('payment_method', [
             'header' => $this->__('Payment Method'),
             'index'  => 'payment_method',
             'filter' => false,
-            'sortable'  => false,
+            'sortable'  => false
         ]);
 /*
         Descomentar esse trecho para adicionar os botões de ações

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Standard.php
@@ -2,7 +2,6 @@
 
 class Mundipagg_Paymentmodule_Model_Standard extends Mage_Payment_Model_Method_Abstract
 {
-
     protected $_allowCurrencyCode = [];
 
     public function __construct()

--- a/app/design/frontend/base/default/layout/paymentmodule.xml
+++ b/app/design/frontend/base/default/layout/paymentmodule.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <layout version="0.1.0">
+
     <mundipagg_checkout_handle>
         <reference name="head">
             <action method="addItem">
@@ -16,6 +17,10 @@
                 </action>
                 <action method="addItem">
                     <type>js</type>
+                    <name>mundipagg/AbstractCheckoutModuleHandler.js</name>
+                </action>
+                <action method="addItem">
+                    <type>js</type>
                     <name>mundipagg/formoperations.js</name>
                 </action>
             </block>
@@ -24,15 +29,31 @@
 
     <checkout_onepage_index translate="label">
         <update handle="mundipagg_checkout_handle"/>
+        <reference name="before_body_end">
+            <block type="page/html_head" name="mp-paymentmodule-onepage-handler" as="mp-paymentmodule-onepage-handler" after="-" template="paymentmodule/extras.phtml">
+                <action method="addItem">
+                    <type>js</type>
+                    <name>mundipagg/OnepageCheckoutModuleHandler.js</name>
+                </action>
+            </block>
+        </reference>
     </checkout_onepage_index>
+
+    <onestepcheckout_index_index translate="label">
+        <update handle="mundipagg_checkout_handle"/>
+        <reference name="before_body_end">
+            <block type="page/html_head" name="mp-paymentmodule-osc-handler" as="mp-paymentmodule-osc-handler" after="-" template="paymentmodule/extras.phtml">
+                <action method="addItem">
+                    <type>js</type>
+                    <name>mundipagg/OSCCheckoutModuleHandler.js</name>
+                </action>
+            </block>
+        </reference>
+    </onestepcheckout_index_index>
 
     <onepagecheckout_index_index translate="label">
         <update handle="mundipagg_checkout_handle"/>
     </onepagecheckout_index_index>
-
-    <onestepcheckout_index_index translate="label">
-        <update handle="mundipagg_checkout_handle"/>
-    </onestepcheckout_index_index>
 
     <opc_index_index translate="label">
         <update handle="mundipagg_checkout_handle"/>

--- a/app/design/frontend/base/default/template/paymentmodule/form/builder.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/builder.phtml
@@ -22,7 +22,7 @@ $orderTotal = $this->getGrandTotal();
     </ul>
     <script type="text/javascript">
         jQuery(document).ready(function(){
-            initPaymentMethod('<?php echo $_code; ?>','<?php echo $orderTotal; ?>');
+            MundiPagg.initPaymentMethod('<?php echo $_code; ?>','<?php echo $orderTotal; ?>');
         });
     </script>
 </fieldset>

--- a/app/design/frontend/base/default/template/paymentmodule/form/builder.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/builder.phtml
@@ -20,9 +20,9 @@ $orderTotal = $this->getGrandTotal();
             </div>
         </li>
     </ul>
-    <script type="javascript">
-
-        initPaymentMethod('<?php echo $_code; ?>','<?php echo $orderTotal; ?>');
-
+    <script type="text/javascript">
+        jQuery(document).ready(function(){
+            initPaymentMethod('<?php echo $_code; ?>','<?php echo $orderTotal; ?>');
+        });
     </script>
 </fieldset>

--- a/app/design/frontend/base/default/template/paymentmodule/form/partial/creditcard.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/partial/creditcard.phtml
@@ -111,7 +111,7 @@
         <div
                 id="<?php echo "$elementId"?>_disabled_brand_message"
                 style="display: none;"
-                class="disabledBrandMessae validation-advice"
+                class="disabledBrandMessage validation-advice"
         ><?php echo $this->__('Unavailable brand'); ?></div>
     </div>
 

--- a/app/design/frontend/base/default/template/paymentmodule/form/partial/creditcard.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/partial/creditcard.phtml
@@ -66,7 +66,7 @@
             <select
                     name="payment[<?php echo "$elementId"?>_SavedCreditCard]"
                     id="<?php echo "$elementId"?>_mundicheckout-SavedCreditCard"
-                    onchange="getFormData('<?php echo $elementId?>'); switchNewSaved(this.value, '<?php echo $elementIndex?>'), fillSavedCreditCardInstallments('<?php echo $elementId?>')"
+                    onchange="getFormData('<?php echo $elementId?>'); switchNewSaved(this.value, '<?php echo $elementId?>'), fillSavedCreditCardInstallments('<?php echo $elementId?>')"
                     elementIndex="<?php echo $elementIndex?>"
                     elementId="<?php echo $elementId?>"
                     class="savedCreditCardSelect"
@@ -92,10 +92,10 @@
            id="<?php echo "$elementId"?>_brand_name"
            name="payment[<?php echo "$elementId"?>_brand_name]">
 
-    <label for="<?php echo "$elementId"?>_mundicheckout-number" class="newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <label for="<?php echo "$elementId"?>_mundicheckout-number" class="newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <?php echo $this->__('Card number'); ?><span class="required"></span>
     </label>
-    <div class="input-box newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <div class="input-box newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <span id="<?php echo "$elementId"?>_mundipaggBrandImage" class="mundipaggBrandImage"></span>
         <input type="hidden" id="<?php echo "$elementId"?>_mundipaggBrandName" value="">
         <input
@@ -117,10 +117,10 @@
 
     <label
             for="<?php echo "$elementId"?>_mundicheckout-holdername"
-            class="newCreditCard-<?php echo $elementIndex?>"
+            class="newCreditCard-<?php echo $elementId?>"
             <?php echo $new; ?>
     ><?php echo $this->__('Holder Name'); ?><span class="required"></span></label>
-    <div class="input-box newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <div class="input-box newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <input
                 type="text"
                 data-mundicheckout-input="<?php echo "$elementId"?>_holder_name"
@@ -132,10 +132,10 @@
 
     <label
             for="<?php echo "$elementId"?>_mundicheckout-expmonth"
-            class="newCreditCard-<?php echo $elementIndex?>"
+            class="newCreditCard-<?php echo $elementId?>"
             <?php echo $new; ?>
     ><?php echo $this->__('Expiration date'); ?><span class="required"></span></label>
-    <div class="input-box newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <div class="input-box newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <div class="v-fix">
             <select
                     class="required-entry"
@@ -188,10 +188,10 @@
 
     <label
         for="<?php echo "$elementId"?>_mundicheckout-cvv"
-        class="newCreditCard-<?php echo $elementIndex?>"
+        class="newCreditCard-<?php echo $elementId?>"
         <?php echo $new; ?>
     >CVV<span class="required">*</span></label>
-    <div class="input-box newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <div class="input-box newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <input
                 type="text"
                 data-mundicheckout-input="<?php echo "$elementId"?>_cvv"
@@ -204,7 +204,7 @@
     </div>
 
     <?php if ($isSavedCreditCardsEnabled) : ?>
-    <div class="input-box newCreditCard-<?php echo $elementIndex?>" <?php echo $new; ?>>
+    <div class="input-box newCreditCard-<?php echo $elementId?>" <?php echo $new; ?>>
         <br>
         <input
                 type="checkbox"

--- a/js/mundipagg/AbstractCheckoutModuleHandler.js
+++ b/js/mundipagg/AbstractCheckoutModuleHandler.js
@@ -9,12 +9,27 @@ var AbstractCheckoutModuleHandler = function (methodCode) {
     this.resetBeforeCheckout();
 };
 
-AbstractCheckoutModuleHandler.prototype.resetBeforeCheckout = function (placeOrderFunction) {
+AbstractCheckoutModuleHandler.prototype.resetBeforeCheckout = function (placeOrderFunction,callerObject) {
     this.tokenCheckTable = {};
     this.placeOrderFunction = placeOrderFunction;
+    this.callerObject = callerObject;
+};
+
+AbstractCheckoutModuleHandler.prototype.callPlaceOrderFunction = function() {
+  if(typeof this.callerObject === 'undefined') {
+      return this.placeOrderFunction();
+  }
+  this.callerObject[this.placeOrderFunction.name]();
 };
 
 AbstractCheckoutModuleHandler.prototype.isHandlingNeeded = function () {
+    return !(
+        this.getCurrentPaymentMethod() !== this.methodCode
+    );
+};
+
+//@Todo this method do not belongs to this class...
+AbstractCheckoutModuleHandler.prototype.hasCardInfo = function () {
     var creditCardTokenDiv = '.'  + this.methodCode + "_creditcard_tokenDiv";
     var hasCardInfo = false;
     var _self = this;
@@ -24,10 +39,7 @@ AbstractCheckoutModuleHandler.prototype.isHandlingNeeded = function () {
         hasCardInfo = true;
     }.bind(_self));
 
-    return !(
-        this.getCurrentPaymentMethod() !== this.methodCode ||
-        hasCardInfo === false
-    );
+    return hasCardInfo;
 };
 
 //@Todo this method do not belongs to this class...
@@ -50,7 +62,7 @@ AbstractCheckoutModuleHandler.prototype.handleTokenGenerationResponse = function
             }
         }.bind(_self));
         if (canSave) {
-            this.placeOrderFunction();
+            this.callPlaceOrderFunction();
         }
         return;
     }

--- a/js/mundipagg/AbstractCheckoutModuleHandler.js
+++ b/js/mundipagg/AbstractCheckoutModuleHandler.js
@@ -84,6 +84,65 @@ AbstractCheckoutModuleHandler.prototype.updateInputBalanceValues = function() {
         );
 };
 
+//@Todo this method do not belongs to this class...
+AbstractCheckoutModuleHandler.prototype.setValueInputAutobalanceEvents = function () {
+    //value balance
+    var amountInputs = jQuery('#payment_form_' + this.methodCode).find('.multipayment-value-input');
+
+    //setting autobalance;
+    if (amountInputs.length === 2) { //needs amount auto balance
+        jQuery(amountInputs).each(function(index,element) {
+            var oppositeIndex = index === 0 ? 1 : 0;
+            var oppositeInput = amountInputs[oppositeIndex];
+
+            element.lastValue = jQuery(element).val();
+            jQuery(element).on('input',function(){
+
+                setTimeout(function(){
+                    if (jQuery(element).val() !== element.lastValue) {
+                        element.lastValue = jQuery(element).val();
+                        jQuery(element).change();
+                    }
+                }.bind(element),2000);
+
+            }.bind(element));
+
+            jQuery(element).on('change',function(){
+                var max = parseFloat(MundiPagg.grandTotal);
+                var elementValue = parseFloat(jQuery(element).val());
+
+                if (isNaN(elementValue)) {
+                    elementValue = 0;
+                }
+
+                if (elementValue > max) {
+                    elementValue = max;
+                }
+
+                var oppositeValue = max - elementValue;
+
+                jQuery(oppositeInput).val(oppositeValue.toFixed(2));
+                jQuery(element).val(elementValue.toFixed(2));
+
+                var elementId = element.id.split('_');
+                elementId.pop();
+                getBrandWithDelay(elementId.join('_'));
+
+                var oppositeInputId = oppositeInput.id.split('_');
+                oppositeInputId.pop();
+                getBrandWithDelay(oppositeInputId.join('_'));
+
+            }.bind(element));
+        });
+    }
+};
+
+
+AbstractCheckoutModuleHandler.prototype.init = function() {
+    throw new Error("'init' is abstract!");
+};
+
+
 AbstractCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function() {
     throw new Error("'setSavePaymentInterceptor' is abstract!");
 };

--- a/js/mundipagg/AbstractCheckoutModuleHandler.js
+++ b/js/mundipagg/AbstractCheckoutModuleHandler.js
@@ -1,0 +1,82 @@
+var AbstractCheckoutModuleHandler = function (methodCode) {
+    if (this.constructor === AbstractCheckoutModuleHandler) {
+        throw new Error(
+            "Abstract class '" + this.constructor.name + "' can't be instantiated!"
+        );
+    }
+
+    this.methodCode = methodCode;
+    this.resetBeforeCheckout();
+};
+
+AbstractCheckoutModuleHandler.prototype.resetBeforeCheckout = function (placeOrderFunction) {
+    this.tokenCheckTable = {};
+    this.placeOrderFunction = placeOrderFunction;
+};
+
+AbstractCheckoutModuleHandler.prototype.isHandlingNeeded = function () {
+    var creditCardTokenDiv = '.'  + this.methodCode + "_creditcard_tokenDiv";
+    var hasCardInfo = false;
+    var _self = this;
+
+    jQuery(creditCardTokenDiv).each(function(index, element) {
+        _self.tokenCheckTable[element.id] = false;
+        hasCardInfo = true;
+    }.bind(_self));
+
+    return !(
+        this.getCurrentPaymentMethod() !== this.methodCode ||
+        hasCardInfo === false
+    );
+};
+
+//@Todo this method do not belongs to this class...
+AbstractCheckoutModuleHandler.prototype.handleTokenGenerationResponse = function(response,element) {
+    var _self = this;
+    var elementId = element.id.replace('_tokenDiv', '');
+    var tokenElement = document.getElementById( elementId + '_mundicheckout-token');
+    if (response !== false) {
+        tokenElement.value = response.id;
+
+        jQuery("#"+elementId+"_mundipagg-invalid-credit-card").hide();
+        jQuery("#"+elementId+"_brand_name").val(response.card.brand);
+        this.tokenCheckTable[element.id] = true;
+
+        //check if all tokens are generated.
+        var canSave = true;
+        jQuery('.' + this.methodCode+ "_creditcard_tokenDiv").each(function(index,_element) {
+            if (_self.tokenCheckTable[_element.id] === false) {
+                canSave = false;
+            }
+        }.bind(_self));
+        if (canSave) {
+            this.placeOrderFunction();
+        }
+        return;
+    }
+    tokenElement.value = "";
+    jQuery("#"+elementId+"_mundipagg-invalid-credit-card").show();
+};
+
+//@Todo this method do not belongs to this class...
+AbstractCheckoutModuleHandler.prototype.updateInputBalanceValues = function() {
+    //foreach value input of the paymentMethod
+    //update input balance values
+    jQuery('#payment_form_' + this.methodCode)
+        .find('.multipayment-value-input')
+        .each(
+            function(index,element)
+            {
+                jQuery(element).change();
+            }
+        );
+};
+
+AbstractCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function() {
+    throw new Error("'setSavePaymentInterceptor' is abstract!");
+};
+
+AbstractCheckoutModuleHandler.prototype.getCurrentPaymentMethod = function() {
+    throw new Error("'getCurrentPaymentMethod' is abstract!");
+};
+

--- a/js/mundipagg/OSCCheckoutModuleHandler.js
+++ b/js/mundipagg/OSCCheckoutModuleHandler.js
@@ -10,3 +10,52 @@ OSCCheckoutModuleHandler.prototype =
         'constructor': OSCCheckoutModuleHandler
     });
 
+OSCCheckoutModuleHandler.prototype.getCurrentPaymentMethod = function() {
+    return OSCPayment.currentMethod;
+};
+
+OSCCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function () {
+    var _self = this;
+    if (Object.keys(MundiPagg.paymentMethods).length === 1) {
+        OSCForm.placeOrderButton.stopObserving('click');
+    }
+    OSCForm.placeOrderButton.observe('click',function(){
+        if (OSCForm.validate()) {
+            _self.resetBeforeCheckout(OSCForm.placeOrder,OSCForm);
+            if(!_self.isHandlingNeeded()) {
+                return;
+            }
+
+            if (!_self.hasCardInfo()) {
+                return OSCForm.placeOrder();
+            }
+
+            _self.updateInputBalanceValues();
+
+            //for each of creditcard forms
+            jQuery('.' + _self.methodCode + "_creditcard_tokenDiv").each(function(index,element) {
+                var elementId = element.id.replace('_tokenDiv', '');
+                if (isNewCard(elementId)) {
+                    var key = document.getElementById(element.id)
+                        .getAttribute('data-mundicheckout-app-id');
+                    getCreditCardToken(key, elementId, function(response){
+                        _self.handleTokenGenerationResponse(response,element);
+                    }.bind(_self));
+                    return;
+                }
+                _self.tokenCheckTable[element.id] = true;
+                return;
+            }.bind(_self));
+            var canSend = true;
+            Object.keys(_self.tokenCheckTable).each(function(key){
+                if (_self.tokenCheckTable[key] === false) {
+                    canSend = false;
+                }
+            });
+            if (canSend) {
+                return OSCForm.placeOrder();
+            }
+        }
+    }.bind(_self));
+};
+

--- a/js/mundipagg/OSCCheckoutModuleHandler.js
+++ b/js/mundipagg/OSCCheckoutModuleHandler.js
@@ -1,5 +1,3 @@
-console.log('OSCCheckoutModuleHandler');
-
 var OSCCheckoutModuleHandler = function (methodCode) {
     AbstractCheckoutModuleHandler.call(this,methodCode);
 };

--- a/js/mundipagg/OSCCheckoutModuleHandler.js
+++ b/js/mundipagg/OSCCheckoutModuleHandler.js
@@ -1,0 +1,12 @@
+console.log('OSCCheckoutModuleHandler');
+
+var OSCCheckoutModuleHandler = function (methodCode) {
+    AbstractCheckoutModuleHandler.call(this,methodCode);
+};
+var MundipaggCheckoutHandler = OSCCheckoutModuleHandler;
+
+OSCCheckoutModuleHandler.prototype =
+    Object.create(AbstractCheckoutModuleHandler.prototype, {
+        'constructor': OSCCheckoutModuleHandler
+    });
+

--- a/js/mundipagg/OnepageCheckoutModuleHandler.js
+++ b/js/mundipagg/OnepageCheckoutModuleHandler.js
@@ -3,7 +3,7 @@ console.log('OnepageCheckoutModuleHandler');
 var OnepageCheckoutModuleHandler = function (methodCode) {
     AbstractCheckoutModuleHandler.call(this,methodCode);
 };
-var MundipaggCheckoutHandler = OnepageCheckoutModuleHandler;
+var MundiPaggCheckoutHandler = OnepageCheckoutModuleHandler;
 
 OnepageCheckoutModuleHandler.prototype =
     Object.create(AbstractCheckoutModuleHandler.prototype, {
@@ -12,6 +12,9 @@ OnepageCheckoutModuleHandler.prototype =
 
 OnepageCheckoutModuleHandler.prototype.getCurrentPaymentMethod = function() {
     return payment.currentMethod;
+};
+
+OnepageCheckoutModuleHandler.prototype.init = function() {
 };
 
 OnepageCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function () {

--- a/js/mundipagg/OnepageCheckoutModuleHandler.js
+++ b/js/mundipagg/OnepageCheckoutModuleHandler.js
@@ -1,0 +1,47 @@
+console.log('OnepageCheckoutModuleHandler');
+
+var OnepageCheckoutModuleHandler = function (methodCode) {
+    AbstractCheckoutModuleHandler.call(this,methodCode);
+};
+var MundipaggCheckoutHandler = OnepageCheckoutModuleHandler;
+
+OnepageCheckoutModuleHandler.prototype =
+    Object.create(AbstractCheckoutModuleHandler.prototype, {
+        'constructor': OnepageCheckoutModuleHandler
+    });
+
+OnepageCheckoutModuleHandler.prototype.getCurrentPaymentMethod = function() {
+    return payment.currentMethod;
+};
+
+OnepageCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function () {
+    var _self = this;
+    Payment.prototype.save = Payment.prototype.save.wrap(function(save) {
+        _self.resetBeforeCheckout(save);
+        if(!_self.isHandlingNeeded()) {
+            return _self.placeOrderFunction();
+        }
+
+        _self.updateInputBalanceValues();
+
+        //for each of creditcard forms
+        jQuery('.' + _self.methodCode + "_creditcard_tokenDiv").each(function(index,element) {
+            var elementId = element.id.replace('_tokenDiv', '');
+            if (isNewCard( elementId) ) {
+                var key = document.getElementById(element.id)
+                    .getAttribute('data-mundicheckout-app-id');
+                var validator = new Validation(payment.form);
+                if (payment.validate() && validator.validate()) {
+                    getCreditCardToken(key, elementId, function(response){
+                        _self.handleTokenGenerationResponse(response,element);
+                    }.bind(_self));
+                }
+                return;
+            }
+            _self.tokenCheckTable[element.id] = true;
+            return _self.placeOrderFunction();
+        }.bind(_self));
+    }.bind(_self));
+};
+
+

--- a/js/mundipagg/OnepageCheckoutModuleHandler.js
+++ b/js/mundipagg/OnepageCheckoutModuleHandler.js
@@ -1,5 +1,3 @@
-console.log('OnepageCheckoutModuleHandler');
-
 var OnepageCheckoutModuleHandler = function (methodCode) {
     AbstractCheckoutModuleHandler.call(this,methodCode);
 };

--- a/js/mundipagg/OnepageCheckoutModuleHandler.js
+++ b/js/mundipagg/OnepageCheckoutModuleHandler.js
@@ -18,7 +18,7 @@ OnepageCheckoutModuleHandler.prototype.setSavePaymentInterceptor = function () {
     var _self = this;
     Payment.prototype.save = Payment.prototype.save.wrap(function(save) {
         _self.resetBeforeCheckout(save);
-        if(!_self.isHandlingNeeded()) {
+        if(!_self.isHandlingNeeded() || !_self.hasCardInfo()) {
             return _self.placeOrderFunction();
         }
 

--- a/js/mundipagg/paymentmodule.js
+++ b/js/mundipagg/paymentmodule.js
@@ -386,6 +386,7 @@ function getFormData(elementId) {
     if (typeof toTokenApi[elementId] === 'undefined') {
         toTokenApi[elementId] = { card:{} };
     }
+
     toTokenApi[elementId].card = {
         type: "credit",
         holder_name: clearHolderName(document.getElementById(elementId + '_mundicheckout-holdername')),
@@ -395,9 +396,13 @@ function getFormData(elementId) {
         cvv: clearCvv(document.getElementById(elementId + '_mundicheckout-cvv'))
     };
 
-    var brandName = jQuery('#' + elementId + '_mundicheckout-SavedCreditCard')
-        .find('option:selected').attr('data-brand');
-    jQuery("#" + elementId + "_brand_name").val(brandName);
+    jQuery("#" + elementId + "_brand_name").val('');
+
+    if (!isNewCard(elementId)) {
+        var brandName = jQuery('#' + elementId + '_mundicheckout-SavedCreditCard')
+            .find('option:selected').attr('data-brand');
+        jQuery("#" + elementId + "_brand_name").val(brandName);
+    }
 }
 
 var isElementValueBusy = {};
@@ -482,6 +487,8 @@ function clearBrand(elementId){
 function showBrandImage(brandName,elementId) {
     var html = "<img src='https://dashboard.mundipagg.com/emb/images/brands/" + brandName + ".jpg' ";
     html += " class='mundipaggImage' width='26'>";
+
+    jQuery("#"+elementId+"_brand_name").val(brandName);
 
     jQuery("#"+elementId+"_mundipaggBrandName").val(brandName);
     jQuery("#"+elementId+"_mundipaggBrandImage" ).html(html);

--- a/js/mundipagg/paymentmodule.js
+++ b/js/mundipagg/paymentmodule.js
@@ -174,12 +174,71 @@ function initPaymentMethod(methodCode,orderTotal)
 
 
         if (typeof OSCForm !== 'undefined' ) {
+            OSCPayment.savePayment();
             OSCForm.placeOrderButton.stopObserving('click');
             OSCForm.placeOrderButton.observe('click',function(){
-
                 if (OSCForm.validate()) {
-                    console.log('disparar geração de token');
-                    OSCForm.placeOrder();
+                    var hasCardInfo = false;
+                    var creditCardTokenDiv = '.'  + methodCode + "_creditcard_tokenDiv";
+                    //generate token check table and check if cardInfos exists;
+                    var tokenCheckTable = {};
+
+                    jQuery(creditCardTokenDiv).each(function(index, element) {
+                        tokenCheckTable[element.id] = false;
+                        hasCardInfo = true;
+
+                    });
+                    if(OSCPayment.currentMethod !== methodCode || hasCardInfo === false) {
+                        return OSCForm.placeOrder();
+                    }
+
+                    //foreach value input of the paymentMethod
+                    //update input balance values
+                    jQuery('#payment_form_' + methodCode)
+                        .find('.multipayment-value-input')
+                        .each(
+                            function(index,element)
+                            {
+                                jQuery(element).change();
+                            }
+                        );
+
+                    //for each of creditcard forms
+                    jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
+                        var elementId = element.id.replace('_tokenDiv', '');
+
+                        if (isNewCard(elementId) ) {
+                            var key = document.getElementById(element.id)
+                                .getAttribute('data-mundicheckout-app-id');
+                            var tokenElement = document.getElementById(elementId + '_mundicheckout-token');
+
+                            getCreditCardToken(key, elementId, function (response) {
+                                if (response != false) {
+                                    tokenElement.value = response.id;
+                                    jQuery("#"+elementId+"_mundipagg-invalid-credit-card").hide();
+                                    jQuery("#"+elementId+"_brand_name").val(response.card.brand);
+                                    tokenCheckTable[element.id] = true;
+                                    //check if all tokens are generated.
+                                    var canSave = true;
+                                    jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
+                                        if (tokenCheckTable[element.id] === false) {
+                                            canSave = false;
+                                        }
+                                    });
+                                    if (canSave) {
+                                        return OSCForm.placeOrder();
+                                    }
+                                    return;
+                                }
+                                tokenElement.value = "";
+                                jQuery("#"+elementId+"_mundipagg-invalid-credit-card").show();
+                            });
+                            return;
+                        }
+
+                        tokenCheckTable[element.id] = true;
+                        return;
+                    });
                 }
             });
         }

--- a/js/mundipagg/paymentmodule.js
+++ b/js/mundipagg/paymentmodule.js
@@ -172,72 +172,85 @@ function initPaymentMethod(methodCode,orderTotal)
             }
         );
 
-        Payment.prototype.save = Payment.prototype.save.wrap(function(save) {
-            var hasCardInfo = false;
-            var creditCardTokenDiv = '.'  + methodCode + "_creditcard_tokenDiv";
-            //generate token check table and check if cardInfos exists;
-            var tokenCheckTable = {};
 
-            jQuery(creditCardTokenDiv).each(function(index, element) {
-                tokenCheckTable[element.id] = false;
-                hasCardInfo = true;
+        if (typeof OSCForm !== 'undefined' ) {
+            OSCForm.placeOrderButton.stopObserving('click');
+            OSCForm.placeOrderButton.observe('click',function(){
 
-            });
-            if(this.currentMethod !== methodCode || hasCardInfo === false) {
-                return save();
-            }
-            var prototypeWrapper = this;
-
-            //foreach value input of the paymentMethod
-            //update input balance values
-            jQuery('#payment_form_' + methodCode)
-                .find('.multipayment-value-input')
-                .each(
-                    function(index,element)
-                    {
-                        jQuery(element).change();
-                    }
-                );
-
-            //for each of creditcard forms
-            jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
-                var elementId = element.id.replace('_tokenDiv', '');
-
-                if (isNewCard(elementId) ) {
-                    var key = document.getElementById(element.id)
-                        .getAttribute('data-mundicheckout-app-id');
-                    var tokenElement = document.getElementById(elementId + '_mundicheckout-token');
-                    var validator = new Validation(prototypeWrapper.form);
-                    if (prototypeWrapper.validate() && validator.validate()) {
-                        getCreditCardToken(key, elementId, function (response) {
-                            if (response != false) {
-                                tokenElement.value = response.id;
-                                jQuery("#"+elementId+"_mundipagg-invalid-credit-card").hide();
-                                jQuery("#"+elementId+"_brand_name").val(response.card.brand);
-                                tokenCheckTable[element.id] = true;
-                                //check if all tokens are generated.
-                                var canSave = true;
-                                jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
-                                    if (tokenCheckTable[element.id] === false) {
-                                        canSave = false;
-                                    }
-                                });
-                                if (canSave) {
-                                    save();
-                                }
-                                return;
-                            }
-                            tokenElement.value = "";
-                            jQuery("#"+elementId+"_mundipagg-invalid-credit-card").show();
-                        });
-                    }
-                    return;
+                if (OSCForm.validate()) {
+                    console.log('disparar geração de token');
+                    OSCForm.placeOrder();
                 }
-
-                tokenCheckTable[element.id] = true;
-                return save();
             });
-        });
+        }
+        else {
+            Payment.prototype.save = Payment.prototype.save.wrap(function(save) {
+                var hasCardInfo = false;
+                var creditCardTokenDiv = '.'  + methodCode + "_creditcard_tokenDiv";
+                //generate token check table and check if cardInfos exists;
+                var tokenCheckTable = {};
+
+                jQuery(creditCardTokenDiv).each(function(index, element) {
+                    tokenCheckTable[element.id] = false;
+                    hasCardInfo = true;
+
+                });
+                if(this.currentMethod !== methodCode || hasCardInfo === false) {
+                    return save();
+                }
+                var prototypeWrapper = this;
+
+                //foreach value input of the paymentMethod
+                //update input balance values
+                jQuery('#payment_form_' + methodCode)
+                    .find('.multipayment-value-input')
+                    .each(
+                        function(index,element)
+                        {
+                            jQuery(element).change();
+                        }
+                    );
+
+                //for each of creditcard forms
+                jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
+                    var elementId = element.id.replace('_tokenDiv', '');
+
+                    if (isNewCard(elementId) ) {
+                        var key = document.getElementById(element.id)
+                            .getAttribute('data-mundicheckout-app-id');
+                        var tokenElement = document.getElementById(elementId + '_mundicheckout-token');
+                        var validator = new Validation(prototypeWrapper.form);
+                        if (prototypeWrapper.validate() && validator.validate()) {
+                            getCreditCardToken(key, elementId, function (response) {
+                                if (response != false) {
+                                    tokenElement.value = response.id;
+                                    jQuery("#"+elementId+"_mundipagg-invalid-credit-card").hide();
+                                    jQuery("#"+elementId+"_brand_name").val(response.card.brand);
+                                    tokenCheckTable[element.id] = true;
+                                    //check if all tokens are generated.
+                                    var canSave = true;
+                                    jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
+                                        if (tokenCheckTable[element.id] === false) {
+                                            canSave = false;
+                                        }
+                                    });
+                                    if (canSave) {
+                                        save();
+                                    }
+                                    return;
+                                }
+                                tokenElement.value = "";
+                                jQuery("#"+elementId+"_mundipagg-invalid-credit-card").show();
+                            });
+                        }
+                        return;
+                    }
+
+                    tokenCheckTable[element.id] = true;
+                    return save();
+                });
+            });
+        }
 
         //value balance
         var amountInputs = jQuery('#payment_form_' + methodCode).find('.multipayment-value-input');

--- a/js/mundipagg/paymentmodule.js
+++ b/js/mundipagg/paymentmodule.js
@@ -185,75 +185,6 @@ function initPaymentMethod(methodCode,orderTotal)
             }
         );
 
-        if (typeof OSCForm !== 'undefined' && false) {
-            OSCForm.placeOrderButton.stopObserving('click');
-            OSCForm.placeOrderButton.observe('click',function(){
-                if (OSCForm.validate()) {
-                    var hasCardInfo = false;
-                    var creditCardTokenDiv = '.'  + methodCode + "_creditcard_tokenDiv";
-                    //generate token check table and check if cardInfos exists;
-                    var tokenCheckTable = {};
-
-                    jQuery(creditCardTokenDiv).each(function(index, element) {
-                        tokenCheckTable[element.id] = false;
-                        hasCardInfo = true;
-
-                    });
-                    if(OSCPayment.currentMethod !== methodCode || hasCardInfo === false) {
-                        return OSCForm.placeOrder();
-                    }
-
-                    //foreach value input of the paymentMethod
-                    //update input balance values
-                    jQuery('#payment_form_' + methodCode)
-                        .find('.multipayment-value-input')
-                        .each(
-                            function(index,element)
-                            {
-                                jQuery(element).change();
-                            }
-                        );
-
-                    //for each of creditcard forms
-                    jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
-                        var elementId = element.id.replace('_tokenDiv', '');
-
-                        if (isNewCard(elementId) ) {
-                            var key = document.getElementById(element.id)
-                                .getAttribute('data-mundicheckout-app-id');
-                            var tokenElement = document.getElementById(elementId + '_mundicheckout-token');
-
-                            getCreditCardToken(key, elementId, function (response) {
-                                if (response != false) {
-                                    tokenElement.value = response.id;
-                                    jQuery("#"+elementId+"_mundipagg-invalid-credit-card").hide();
-                                    jQuery("#"+elementId+"_brand_name").val(response.card.brand);
-                                    tokenCheckTable[element.id] = true;
-                                    //check if all tokens are generated.
-                                    var canSave = true;
-                                    jQuery('.' +methodCode+ "_creditcard_tokenDiv").each(function(index,element) {
-                                        if (tokenCheckTable[element.id] === false) {
-                                            canSave = false;
-                                        }
-                                    });
-                                    if (canSave) {
-                                        return OSCForm.placeOrder();
-                                    }
-                                    return;
-                                }
-                                tokenElement.value = "";
-                                jQuery("#"+elementId+"_mundipagg-invalid-credit-card").show();
-                            });
-                            return;
-                        }
-
-                        tokenCheckTable[element.id] = true;
-                        return;
-                    });
-                }
-            });
-        }
-
         //value balance
         var amountInputs = jQuery('#payment_form_' + methodCode).find('.multipayment-value-input');
 
@@ -398,7 +329,7 @@ function getFormData(elementId) {
         cvv: clearCvv(document.getElementById(elementId + '_mundicheckout-cvv'))
     };
 
-    jQuery("#" + elementId + "_brand_name").val('');
+    //jQuery("#" + elementId + "_brand_name").val('');
 
     if (!isNewCard(elementId)) {
         var brandName = jQuery('#' + elementId + '_mundicheckout-SavedCreditCard')
@@ -471,6 +402,7 @@ function getBrand(elementId) {
 
 function fillBrandData(data,argsObj) {
     if (data.brand != "" && data.brand != undefined) {
+
         showBrandImage(data.brand,argsObj.elementId);
         getInstallments(jQuery("#baseUrl").val(), data.brandName,argsObj);
 
@@ -525,7 +457,7 @@ function getInstallments(baseUrl, brandName, argsObj) {
 }
 
 function switchInstallments(data,argsObj) {
-    jQuery('.disabledBrandMessae').hide();
+    jQuery('.disabledBrandMessage').hide();
 
     if (data) {
         var withoutInterest = MundiPagg.Locale.getTranslaction("without interest");


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | mundipagg/plug-team#252
| What?         | Add Multiple checkout module support
| Why?          | The module needs to work flawlessly with multiple checkout modules, like **OneStepCheckout**.
| How?          | Separating frontend checkout process actions into a class family, where each is class responsible for one checkout module.