### PR TITLE
Fix cancel/capture failure handling

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/controllers/ChargeController.php
+++ b/app/code/community/Mundipagg/Paymentmodule/controllers/ChargeController.php
@@ -129,6 +129,11 @@ class Mundipagg_Paymentmodule_ChargeController extends Mage_Core_Controller_Fron
                     return;
                 }
 
+                if (!$response->lastTransaction->success) {
+                    $this->setResponse('403','Operation failed');
+                    return;
+                }
+
                 $chargeOperations = Mage::helper('paymentmodule/chargeoperations');
                 $chargeOperations->setTransactionAsHandled(
                     $response->code,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | mundipagg/plug-team#279
| What?         | Fix cancel/capture failure handling
| Why?          | If the capture or cancel fails, the module don't handle it correctly
| How?          | Checking the value of **success** node on **lastTransaction** node on capture/cancel response.