### PR TITLE
Fix value of charge paid

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/Block/Adminhtml/Order/Charge/Grid.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Block/Adminhtml/Order/Charge/Grid.php
@@ -56,7 +56,7 @@ class Mundipagg_Paymentmodule_Block_Adminhtml_Order_Charge_Grid extends Mage_Adm
                 $captureTransactions = array_filter(
                     $chargeHistory,
                     function($history) {
-                        return $history['type'] == 'capture';
+                        return strpos($history['type'], 'capture') !== false;
                     }
                 );
                 $item['paid_amount'] = 0.000000001;
@@ -76,6 +76,10 @@ class Mundipagg_Paymentmodule_Block_Adminhtml_Order_Charge_Grid extends Mage_Adm
                     $item['canceled_amount'] += $canceled['amount'];
                 }
                 $item['canceled_amount'] = $item['canceled_amount'] / 100;
+
+                if ($item['canceled_amount'] > $item['amount']) {
+                    $item['canceled_amount'] = $item['amount'];
+                }
 
                 $rowObj = new Varien_Object();
                 $rowObj->setData($item);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | https://github.com/mundipagg/plug-team/issues/297
| What?         | Fix value of charge paid
| Why?          | To show the correct value when the charge is canceled and the operation type is auth and capture
| How?          | Verify if the history type has the string 'capture' to increment the canceled value
