### PR TITLE
Fix document filtering to accept only numbers send to api

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
@@ -189,11 +189,16 @@ abstract class Mundipagg_Paymentmodule_Model_Api_Standard
 
         $document = preg_replace('/[^0-9]/', '', $customer['multiBuyerTaxvat']);
 
+        $type = 'individual';
+        if (strlen($document) > 11) {
+            $type = 'company';
+        }
+
         $customerRequest->name = $customer['multiBuyerName'];
         $customerRequest->email = $customer['multiBuyerEmail'];
         $customerRequest->document = $document;
         $customerRequest->address = $this->getAddressFromMultiBuyer($customer);
-        $customerRequest->type = 'individual';
+        $customerRequest->type = $type;
 
         return $customerRequest;
     }

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
@@ -187,9 +187,11 @@ abstract class Mundipagg_Paymentmodule_Model_Api_Standard
     {
         $customerRequest = new CreateCustomerRequest();
 
+        $document = preg_replace('/[^0-9]/', '', $customer['multiBuyerTaxvat']);
+
         $customerRequest->name = $customer['multiBuyerName'];
         $customerRequest->email = $customer['multiBuyerEmail'];
-        $customerRequest->document = $customer['multiBuyerTaxvat'];
+        $customerRequest->document = $document;
         $customerRequest->address = $this->getAddressFromMultiBuyer($customer);
         $customerRequest->type = 'individual';
 

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Standard.php
@@ -105,13 +105,15 @@ class Mundipagg_Paymentmodule_Model_Standard extends Mage_Payment_Model_Method_A
 
         $customer = new Varien_Object();
 
+        $document = preg_replace('/[^0-9]/', '',$order->getCustomerTaxvat());
+
         $name = $order->getCustomerFirstname();
         $name .= ' ' .  $order->getCustomerMiddlename();
         $name .= ' ' .  $order->getCustomerLastname();
         $customer->setName($name);
         $customer->setEmail($order->getCustomerEmail());
         $customer->setId(null);
-        $customer->setDocument($order->getCustomerTaxvat());
+        $customer->setDocument($document);
         $customer->setCustomer($customer);
 
         return $customer;

--- a/app/design/frontend/base/default/template/paymentmodule/form/partial/multibuyer.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/partial/multibuyer.phtml
@@ -47,6 +47,8 @@
             id="<?php echo $elementId; ?>_multi_buyer_taxvat"
             name="payment[<?php echo $elementId; ?>_multiBuyerTaxvat]"
             class="<?php echo $elementClass; ?>_validate-mundipagg-cpf required-entry"
+            onkeyup="validateTaxVat(this)"
+            maxlength="16"
     />
 
     <div class="input-box">

--- a/app/design/frontend/base/default/template/paymentmodule/form/partial/multibuyer.phtml
+++ b/app/design/frontend/base/default/template/paymentmodule/form/partial/multibuyer.phtml
@@ -48,7 +48,7 @@
             name="payment[<?php echo $elementId; ?>_multiBuyerTaxvat]"
             class="<?php echo $elementClass; ?>_validate-mundipagg-cpf required-entry"
             onkeyup="validateTaxVat(this)"
-            maxlength="16"
+            maxlength="14"
     />
 
     <div class="input-box">

--- a/js/mundipagg/multibuyer.js
+++ b/js/mundipagg/multibuyer.js
@@ -33,3 +33,8 @@ function buildStatesOptions(data) {
 
     return html;
 }
+
+
+function validateTaxVat(element) {
+    $(element).value = $(element).value.replace(/[^0-9]/g, '');
+} 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | https://mundipagg.atlassian.net/browse/MOD-353
| What?         | Fix document filtering to accept only numbers send to api
| Why?          | The API do not accept characters non numerics on document field
| How?          | Filter the field of document to replace characters non numerics
