### PR TITLE
Add shipping type and fingerprint info to order creation request

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
@@ -90,6 +90,7 @@ abstract class Mundipagg_Paymentmodule_Model_Api_Standard
         $shippingRequest->amount = round($shippingInformation->getAmount());
         $shippingRequest->description = $shippingInformation->getDescription();
         $shippingRequest->address = $this->getCreateAddressRequest($address);
+        $shippingRequest->type =  $shippingInformation->getMethod();
 
         return $shippingRequest;
     }

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
@@ -19,7 +19,7 @@ abstract class Mundipagg_Paymentmodule_Model_Api_Standard
 
         $sessionId = $session->getData(self::SESSION_ID);
 
-        if (is_null($sessionId) || $sessionId == false || empty($sessionId)) {
+        if (empty($sessionId)) {
             $sessionId = uniqid('mpm1-');
             $session->setData(self::SESSION_ID, $sessionId);
         }

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Api/Standard.php
@@ -11,6 +11,22 @@ use Mundipagg_Paymentmodule_Helper_Address as AddressHelper;
 
 abstract class Mundipagg_Paymentmodule_Model_Api_Standard
 {
+    const SESSION_ID = 'mp_session_id';
+
+    protected function getMageSessionId()
+    {
+        $session = Mage::getSingleton('customer/session');
+
+        $sessionId = $session->getData(self::SESSION_ID);
+
+        if (is_null($sessionId) || $sessionId == false || empty($sessionId)) {
+            $sessionId = uniqid('mpm1-');
+            $session->setData(self::SESSION_ID, $sessionId);
+        }
+
+        return $sessionId;
+    }
+
     protected function getCurrentCurrencyCode()
     {
         return Mage::app()->getStore()->getCurrentCurrencyCode();
@@ -32,6 +48,7 @@ abstract class Mundipagg_Paymentmodule_Model_Api_Standard
         $orderRequest->metadata = $paymentInformation->getMetainfo();
         $orderRequest->shipping = $this->getShippingRequest($paymentInformation->getShippingInfo());
         $orderRequest->antifraudEnabled = $paymentInformation->getSendToAntiFraud();
+        $orderRequest->sessionId = $this->getMageSessionId();
 
         return $orderRequest;
     }

--- a/app/code/community/Mundipagg/Paymentmodule/Model/Paymentmethods/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Paymentmethods/Standard.php
@@ -205,6 +205,7 @@ class Mundipagg_Paymentmodule_Model_Paymentmethods_Standard extends Mundipagg_Pa
         $shipping->setAmount($monetaryHelper->toCents($amount));
         $shipping->setDescription($order->getShippingDescription());
         $shipping->setAddress($this->getShippingAddressInformation($order));
+        $shipping->setMethod($order->getShippingMethod());
 
         return $shipping;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | https://mundipagg.atlassian.net/browse/MOD-696
|                    | https://mundipagg.atlassian.net/browse/MOD-697
| What?         | Add shipping type and fingerprint info to order creation request.
| Why?          | To send some info that will be used by antifraud providers.
