### PR TITLE
Fix the email send when has a new order

### DIFF
--- a/app/code/community/Mundipagg/Paymentmodule/Model/Paymentmethods/Standard.php
+++ b/app/code/community/Mundipagg/Paymentmodule/Model/Paymentmethods/Standard.php
@@ -146,6 +146,9 @@ class Mundipagg_Paymentmodule_Model_Paymentmethods_Standard extends Mundipagg_Pa
             );
         }
 
+        $order = $standard->getOrderByIncrementOrderId($orderId);
+        $order->sendNewOrderEmail();
+
         //Update magento order status
         $orderHelper->updateStatus($response, $response->status);
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues        | https://mundipagg.atlassian.net/browse/MOD-732
| What?         | Fix the email send when has a new order
| Why?          | To send email of order successfully created
| How?          | Call the platform order method to send email when is a new order